### PR TITLE
Update build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# mathjax-node [![Build Status](https://travis-ci.org/mathjax/MathJax-node.svg?branch=develop)](https://travis-ci.org/mathjax/MathJax-node)
+# mathjax-node [![Build Status](https://travis-ci.org/wikimedia/MathJax-node.svg?branch=master)](https://travis-ci.org/wikimedia/MathJax-node)
 
 This repository contains files that provide APIs to call MathJax from 
 node.js programs.  There is an API for converting individual math 


### PR DESCRIPTION
The old badge pointed to mathjax/develop which has failing
tests from time to time.