### PR TITLE
Fix: Replace all currentColor attributes with black

### DIFF
--- a/lib/mj-single.js
+++ b/lib/mj-single.js
@@ -514,7 +514,7 @@ function GetPNG(result) {
     if (data.png) {
         var svgRenderer = new rsvg();
         s._read = function () {
-            s.push(svgFile.replace('="currentColor"','="black"'));
+            s.push(svgFile.replace(/="currentColor"/g,'="black"'));
             s.push(null);
         };
         var synch = MathJax.Callback(function () {}); // for synchronization with MathJax

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mathoid-mathjax-node",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "API's for calling MathJax from node.js",
   "keywords": [
     "MathJax",


### PR DESCRIPTION
on my vagrant test instance `./bin/tex2png 'E=mc^2'` produces
![emc](https://cloud.githubusercontent.com/assets/2777736/14467940/9d84c6ba-00ab-11e6-8795-22573e02bb3a.png)

