### PR TITLE
Use dpi setting for PNG generation

### DIFF
--- a/lib/mj-single.js
+++ b/lib/mj-single.js
@@ -59,7 +59,7 @@ var defaults = {
   svg: false,                     // return svg output?
   mathoidStyle: false,            // return mathoidStyle tag for remote image?
   png: false,                     // return png image (as data: URL)?
-  dpi: 144,                       // dpi for png image
+  dpi: 180,                       // dpi for png image
 
   speakText: false,               // add spoken annotations to svg output?
   speakRuleset: "mathspeak",      // set speech ruleset (default (chromevox rules), mathspeak)
@@ -507,7 +507,7 @@ function GetSVG(result) {
 //
 function GetPNG(result) {
     var s = new Readable();
-    var pngScale = 2;
+    var pngScale = data.dpi / 90; // 90 DPI is the effective setting used by librsvg
     var svgFile = result.svgfile; result.svgfile=undefined;
     var width = result.width; result.width=undefined;
     var height = result.height; result.height=undefined;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mathoid-mathjax-node",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "API's for calling MathJax from node.js",
   "keywords": [
     "MathJax",


### PR DESCRIPTION
node-librsvg has a fixed dpi setting of 90 DPI. To overwrite that we changed the size of the PNG image.
However, this is confusing since MathJaxNode has a build in setting for the resolution.
We change the default to 180 so that this change does not affect the images if no DPI
setting is passed. 