### PR TITLE
Survive librsvg errors

### DIFF
--- a/lib/mj-single.js
+++ b/lib/mj-single.js
@@ -510,25 +510,30 @@ function GetPNG(result) {
     var svgFile = result.svgfile; result.svgfile=undefined;
     var width = result.width; result.width=undefined;
     var height = result.height; result.height=undefined;
-    if (data.png) {
-        var svgRenderer = new rsvg();
-        s._read = function () {
-            s.push(svgFile.replace(/="currentColor"/g,'="black"'));
-            s.push(null);
-        };
-        var synch = MathJax.Callback(function () {}); // for synchronization with MathJax
-        svgRenderer.on('finish', function () {
+    if (!data.png) {
+        return;
+    }
+    var svgRenderer = new rsvg();
+    s._read = function () {
+        s.push(svgFile.replace(/="currentColor"/g,'="black"'));
+        s.push(null);
+    };
+    var synch = MathJax.Callback(function () {}); // for synchronization with MathJax
+    svgRenderer.on('finish', function () {
+        try {
             var buffer = svgRenderer.render({
                 format: 'png',
                 width: width * pngScale,
                 height: height * pngScale
             }).data;
             result.png = buffer || new Buffer();
-            synch();
-        });
-        s.pipe(svgRenderer);
-        return synch;  // This keeps the queue from continuing until the readFile() is complete
-    }
+        } catch(e) {
+            result.errors = e.message;
+        }
+        synch();
+    });
+    s.pipe(svgRenderer);
+    return synch;  // This keeps the queue from continuing until the readFile() is complete
 }
 
 /********************************************************************/

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "speech-rule-engine": "0.9.2",
     "yargs": "^3.0.0",
     "mathoid-mathjax": "2.5.3",
-    "librsvg": "^0.6.1"
+    "librsvg": "^0.7.0"
   },
   "scripts": {
     "test": "tape test/*.js"

--- a/test/png-error.js
+++ b/test/png-error.js
@@ -1,0 +1,18 @@
+var tape = require('tape');
+var mjAPI = require("..//lib/mj-single.js");
+
+tape('PNG rendering: input with invalid render dimensions', function(t) {
+    t.plan(1);
+
+    var tex = '\\textstyle{}';  // from https://phabricator.wikimedia.org/T134652
+    mjAPI.start();
+
+    mjAPI.typeset({
+        math: tex,
+        format: "inline-TeX",
+        png: true,
+        mathoidStyle: true
+    }, function (data) {
+        t.ok(/Expected width > 0/.test(data.errors), 'Dimensions are invalid');
+    });
+});


### PR DESCRIPTION
When librsvg fails to render a PNG, it throws an exception which was not handled properly in MathJax-node. This PR makes it catch the exceptions and report them via result.errors.

Bug: [T134652](https://phabricator.wikimedia.org/T134652)